### PR TITLE
fixed off-by-one bug in the calculation of shm_name->len

### DIFF
--- a/ngx_http_upstream_fair_module.c
+++ b/ngx_http_upstream_fair_module.c
@@ -610,7 +610,7 @@ ngx_http_upstream_init_fair(ngx_conf_t *cf, ngx_http_upstream_srv_conf_t *us)
     n = peers->number;
 
     shm_name = ngx_palloc(cf->pool, sizeof *shm_name);
-    shm_name->len = sizeof("upstream_fair");
+    shm_name->len = sizeof("upstream_fair") - 1;
     shm_name->data = (unsigned char *) "upstream_fair";
 
     if (ngx_http_upstream_fair_shm_size == 0) {


### PR DESCRIPTION
shm_name->len should be the length of the string, not the number of bytes in the character array (which includes the null sentinel)
